### PR TITLE
chore: Remove snyk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,30 +6,13 @@ defaults: &defaults
     - image: robcresswell/circleci-node-alpine
 commands:
   install_deps:
-    description: Install dependencies (from cache, if possible)
+    description: Install dependencies
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            # when lock file changes, use increasingly general patterns to restore cache
-            - yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - yarn-{{ .Branch }}-
-            - yarn-
       - run:
           name: Install dependencies
           command: yarn --frozen-lockfile
-      - save_cache:
-          paths:
-            - ~/.cache/yarn
-          key: yarn-{{ .Branch }}-{{ checksum "yarn.lock" }}
 jobs:
-  snyk:
-    <<: *defaults
-    steps:
-      - checkout
-      - run:
-          name: Run snyk
-          command: npx snyk test
   release:
     <<: *defaults
     steps:
@@ -39,7 +22,4 @@ workflows:
   version: 2
   test_and_release:
     jobs:
-      - snyk
-      - release:
-          requires:
-            - snyk
+      - release


### PR DESCRIPTION
snyk isn't really that useful for libraries, given that it picks up full paths from lockfiles, which are ignored by applications installation this anyway