### PR TITLE
feat:Don't compress server files

### DIFF
--- a/module.js
+++ b/module.js
@@ -5,8 +5,8 @@ module.exports = compressionModule;
 module.exports.meta = require('./package.json');
 
 function compressionModule() {
-  this.extendBuild((config, { isDev }) => {
-    if (isDev) {
+  this.extendBuild((config, { isDev, isServer }) => {
+    if (isDev || isServer) {
       return;
     }
 


### PR DESCRIPTION
When building nuxt in universal mode, skip assets compression for the server since they wont be used by nodejs.